### PR TITLE
Fix table overflowing in firefox

### DIFF
--- a/src/components/notice.js
+++ b/src/components/notice.js
@@ -122,10 +122,10 @@ class Notice extends Component {
             {banner.name}
           </Table.Cell>
         ) : (
-          <></>
+          null
         )}
         <Table.Cell
-          width={10}
+          width={ isMobile ? 7 : 10 }
           collapsing
           onClick={this.openNotice}
           styleName='notice.cell-width-4 notice.cell-hover'
@@ -149,23 +149,19 @@ class Notice extends Component {
             {uploader.fullName}
           </Table.Cell>
         ) : (
-          <></>
+          null
         )}
-        {!isMobile ? (
-          <Table.Cell
-            width={4}
-            onClick={this.openNotice}
-            textAlign='center'
-            collapsing
-            styleName='notice.cell-width-2 notice.cell-hover'
-          >
-            {moment(date).format(
-              Date.now().year === moment(date).year() ? 'DD/MM/YY' : 'MMM Do'
-            )}
-          </Table.Cell>
-        ) : (
-          <></>
-        )}
+        <Table.Cell
+          width={ isMobile ? 3 : 4 }
+          onClick={this.openNotice}
+          textAlign='center'
+          collapsing
+          styleName='notice.cell-width-2 notice.cell-hover'
+        >
+          {moment(date).format(
+            Date.now().year === moment(date).year() ? 'DD/MM/YY' : 'MMM Do'
+          )}
+        </Table.Cell>
         {permission.length > 0 ? (
           <>
             {!expired ? (

--- a/src/components/notice.js
+++ b/src/components/notice.js
@@ -86,6 +86,7 @@ class Notice extends Component {
         {(user && ifRole(user.roles, 'Guest') === 'IS_ACTIVE') ||
         expired ? null : (
           <Table.Cell
+            width={1}
             styleName={'notice.cell-width-1 notice.cell-hover'}
             onClick={this.selectNotice}
             collapsing
@@ -100,6 +101,7 @@ class Notice extends Component {
         {(user && ifRole(user.roles, 'Guest') === 'IS_ACTIVE') ||
         expired ? null : (
           <Table.Cell
+            width={1}
             styleName={'notice.cell-width-1 notice.cell-hover'}
             onClick={this.bookmarkNotice}
           >
@@ -111,6 +113,7 @@ class Notice extends Component {
         )}
         {!isMobile ? (
           <Table.Cell
+            width={4}
             collapsing
             onClick={this.openNotice}
             styleName='notice.cell-width-2 notice.cell-hover'
@@ -122,17 +125,16 @@ class Notice extends Component {
           <></>
         )}
         <Table.Cell
+          width={10}
           collapsing
           onClick={this.openNotice}
-          styleName='notice.cell-hover notice.cell-width-4'
+          styleName='notice.cell-width-4 notice.cell-hover'
           title={title}
         >
           <span styleName='notice.tag-margin-right'>
             {important ? (
               <Icon name='tag' color='blue' />
-            ) : (
-              <Icon name={null} />
-            )}
+            ) : null}
           </span>
           {title}
         </Table.Cell>
@@ -141,6 +143,7 @@ class Notice extends Component {
             onClick={this.openNotice}
             collapsing
             styleName='notice.cell-width-2 notice.cell-hover'
+            width={2}
             title={uploader.fullName}
           >
             {uploader.fullName}
@@ -150,6 +153,7 @@ class Notice extends Component {
         )}
         {!isMobile ? (
           <Table.Cell
+            width={4}
             onClick={this.openNotice}
             textAlign='center'
             collapsing
@@ -174,6 +178,7 @@ class Notice extends Component {
                 collapsing
                 textAlign='center'
                 styleName='notice.cell-width-1'
+                width={1}
               >
                 {uploader && uploader.id === user.id ? (
                   <Icon name='pencil' styleName='notice.cell-hover' />
@@ -189,6 +194,7 @@ class Notice extends Component {
               collapsing
               textAlign='center'
               styleName='notice.cell-width-1'
+              width={1}
             >
               {uploader && uploader.id === user.id ? (
                 <Icon name='trash' styleName='notice.cell-hover' />

--- a/src/css/notice.css
+++ b/src/css/notice.css
@@ -240,32 +240,33 @@
 }
 
 .cell-width-1 {
-  width: 0.205% !important;
+  /* width: 0.205% !important; */
   color: #999999;
   overflow: visible !important;
   padding-left: 1.25% !important;
 }
 
 .cell-width-2 {
-  width: 0.6% !important;
+  /* width: 0.6% !important; */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   color: #878787;
+  text-align: left !important;
 }
 
 .cell-width-3 {
-  width: 0.9% !important;
+  /* width: 0.9% !important; */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: center;
+  text-align: left !important;
   color: #878787;
 }
 
 .cell-width-4 {
-  max-width: 2.5rem !important;
-  text-align: center;
+  /* max-width: 2.5rem !important; */
+  text-align: left !important;
   white-space: nowrap;
   box-sizing: content-box;
   overflow: hidden;

--- a/src/css/notice.css
+++ b/src/css/notice.css
@@ -240,14 +240,12 @@
 }
 
 .cell-width-1 {
-  /* width: 0.205% !important; */
   color: #999999;
   overflow: visible !important;
   padding-left: 1.25% !important;
 }
 
 .cell-width-2 {
-  /* width: 0.6% !important; */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -256,7 +254,6 @@
 }
 
 .cell-width-3 {
-  /* width: 0.9% !important; */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -265,7 +262,6 @@
 }
 
 .cell-width-4 {
-  /* max-width: 2.5rem !important; */
   text-align: left !important;
   white-space: nowrap;
   box-sizing: content-box;
@@ -400,11 +396,5 @@
   .search-menu-item {
     padding: 0 !important;
     margin: 0.5rem 0 !important;
-  }
-}
-
-@media only screen and (max-width: 1000px) {
-  .cell-width-1 {
-    width: 0.14% !important;
   }
 }


### PR DESCRIPTION
Fixed overflowing of notices table in mozilla firefox by using semantics table attribute "width" in place of percentages.
![Screenshot from 2020-10-02 04-42-24](https://user-images.githubusercontent.com/43586052/94872398-26448000-046a-11eb-86aa-54581da4b422.png)
