### PR TITLE
Encode search and date URL params (Rewrite-targeted equivalent of #14)

### DIFF
--- a/src/urls.js
+++ b/src/urls.js
@@ -58,7 +58,7 @@ export function addImportantUrl(url) {
 
 export function searchGetParamUrl(url, search_keyword) {
     if (search_keyword) {
-        url += `&keyword=${search_keyword}`
+        url += `&keyword=${encodeURIComponent(search_keyword)}`
     }
     return url
 }
@@ -111,10 +111,10 @@ export const bannerUrl = (bannerId = null, searchKeyword = null, dateFilter = nu
     }
     url += `?page=1`
     if(dateFilter) {
-        url += `&date=${dateFilter.start+'/'+dateFilter.end}`
+        url += `&date=${encodeURIComponent(dateFilter.start + '/' + dateFilter.end)}`
     }
     if(searchKeyword) {
-        url += `&search=${searchKeyword}`
+        url += `&search=${encodeURIComponent(searchKeyword)}`
     }
     return url
 }


### PR DESCRIPTION
## Summary

Adds `encodeURIComponent` to three query-parameter writers in `src/urls.js` so search keywords and date filters round-trip safely to the noticeboard backend.

- `searchGetParamUrl(url, search_keyword)` — `keyword=...`
- `bannerUrl({ searchKeyword, dateFilter })` — `search=...` and `date=...`

3 lines changed, all in `src/urls.js`.

## Why this PR

This is the `Rewrite`-targeted equivalent of #14 (which targets `master`). Production builds from `Rewrite`, so #14 cannot reach prod even after merge.

`Rewrite` and `master` share no common ancestor and use fundamentally different state models for filter/search:

- `master` stored filter state in `history.push({ state: { searchKeyword, ... } })` and lost it on refresh — most of #14 is a refactor to fix that by switching to `URLSearchParams`.
- `Rewrite` already drives navigation through `bannerUrl()` writing URL query params, so the URLSearchParams refactor is unnecessary here.

The only meaningful overlap is the URL-encoding fix — and that bug is identical on both branches. This PR contains exactly that fix and nothing else.

## Why now

Coordinated with the in-flight Elasticsearch search work:

- `omniport-app-noticeboard#22` — replaces Postgres `SearchVector` with a 3-tier ES query keyed off the `keyword=` GET param. Without encoding, any search containing `&`, `=`, `#`, `+`, `%`, `/`, or whitespace breaks the API call.
- `omniport-docker#52` and `omniport-docker#53` — provision Elasticsearch (sidecar / env-driven host) for dev and prod.

This PR is the frontend half required to get the new search code path working safely against `Rewrite`-built production.

## Test plan

- [ ] Pull this branch, build, deploy to staging (which now tracks `fix_bugs` → `Rewrite`).
- [ ] Search for a notice with a special character in the keyword (e.g. `R&D`, `100%`, `a + b`). Confirm the request URL contains the encoded form (`R%26D`, `100%25`, `a%20%2B%20b`) and the backend returns matches.
- [ ] Apply a date filter and confirm `&date=YYYY-MM-DD%2FYYYY-MM-DD` appears in the URL.
- [ ] Regression: confirm a plain alphanumeric keyword (e.g. `library`) still returns the same results as before.