### PR TITLE
Encode search and date URL params (Rewrite-targeted equivalent of #14)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/actions/getNotices.js
+++ b/src/actions/getNotices.js
@@ -9,12 +9,13 @@ import {
 import { toast } from 'react-semantic-toasts'
 import { no_of_notices } from '../const'
 
-function requestNotices(page, searchKeyword) {
+function requestNotices(page, searchKeyword, sortMode) {
     return {
         type: 'FETCH_NOTICES_REQUEST',
         payload: {
             page: page,
-            searchKeyword: searchKeyword
+            searchKeyword: searchKeyword,
+            sortMode: sortMode
         }
     }
 }
@@ -27,7 +28,8 @@ function receiveNotices(
     bannerId,
     dateRange,
     mainCategorySlug,
-    showImp
+    showImp,
+    sortMode
 ) {
     let totalPages = Math.ceil(noticeDataList.count / no_of_notices)
     if (totalPages === 0) {
@@ -46,6 +48,7 @@ function receiveNotices(
             notices: noticeDataList.results,
             importantUnreadCount: noticeDataList.importantUnreadCount,
             searchKeyword: searchKeyword,
+            sortMode: sortMode,
             totalPages: totalPages,
             showImp: showImp
         }
@@ -61,11 +64,12 @@ export const getNotices = () => (dispatch, getState) => {
     const mainCategorySlug = getState().notices.mainCategorySlug
     const dateRange = getState().notices.dateRange
     const showImp = getState().notices.showImp
+    const sortMode = getState().notices.sortMode || 'date'
 
-    dispatch(requestNotices(page, searchKeyword))
+    dispatch(requestNotices(page, searchKeyword, sortMode))
     let url
     if (expired) {
-        url = expiredNoticesUrl(page, searchKeyword)
+        url = expiredNoticesUrl(page, searchKeyword, sortMode)
     } else if (dateRange) {
         url = dateFilterUrl(
             page,
@@ -73,16 +77,17 @@ export const getNotices = () => (dispatch, getState) => {
             dateRange.end,
             bannerId,
             mainCategorySlug,
-            searchKeyword
+            searchKeyword,
+            sortMode
         )
     } else if (bannerId) {
-        url = filterUrl(page, bannerId, searchKeyword, mainCategorySlug)
+        url = filterUrl(page, bannerId, searchKeyword, mainCategorySlug, sortMode)
     } else if (narrowBookmark) {
         url = bookmarkedNoticesUrl(page)
     } else if (showImp) {
-        url = importantNoticesUrl(page)
+        url = importantNoticesUrl(page, searchKeyword, sortMode)
     } else {
-        url = noticesUrl(page, searchKeyword)
+        url = noticesUrl(page, searchKeyword, sortMode)
     }
 
     return fetch(url)
@@ -97,7 +102,8 @@ export const getNotices = () => (dispatch, getState) => {
                     bannerId,
                     dateRange,
                     mainCategorySlug,
-                    showImp
+                    showImp,
+                    sortMode
                 )
             )
         )

--- a/src/actions/setFilters.js
+++ b/src/actions/setFilters.js
@@ -1,4 +1,4 @@
-export const setFilters = (page, date, searchKeyword, showImp, expired, narrowBookmark, mainCategorySlug, bannerId) => (dispatch) => {
+export const setFilters = (page, date, searchKeyword, showImp, expired, narrowBookmark, mainCategorySlug, bannerId, sortMode = 'date') => (dispatch) => {
     if(!page){
         page = 1
     }
@@ -12,7 +12,8 @@ export const setFilters = (page, date, searchKeyword, showImp, expired, narrowBo
             expired, 
             narrowBookmark, 
             mainCategorySlug, 
-            bannerId
+            bannerId,
+            sortMode
         }
     })
 }

--- a/src/components/TabList.js
+++ b/src/components/TabList.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import { Container, Menu, Button, Icon, Form, Input, Label } from 'semantic-ui-react'
+import { Container, Menu, Button, Icon, Form, Input, Label, Dropdown } from 'semantic-ui-react'
 import { DatesRangeInput } from 'semantic-ui-calendar-react'
 import { dateFormatMatch } from '../utils'
 
@@ -22,6 +22,7 @@ class TabList extends Component {
         datesRange: '',
         ownUpdateDate: false,
         dateRangeActive: false,
+        sortMode: 'date',
         edit: false,
         noticeId: null
     }
@@ -31,7 +32,8 @@ class TabList extends Component {
         if(!state.ownUpdate) {
             newState = {
                 ...newState,
-                value: nextProps.searchKeyword
+                value: nextProps.searchKeyword,
+                sortMode: nextProps.sortMode || 'date'
             }
         }
         if(!state.ownUpdateDate) {
@@ -92,7 +94,10 @@ class TabList extends Component {
     }
 
     handleDateFilterSubmit = (value) => {
-        const { searchKeyword, history } = this.props
+        const { searchKeyword, history, sortMode } = this.props
+        if (typeof value !== 'string') {
+            value = this.state.datesRange
+        }
         let dateRange, dateRangeActive
         dateRange = dateFormatMatch(value)
         if (dateRange) {
@@ -103,7 +108,8 @@ class TabList extends Component {
         if (dateRangeActive) {
             let url = `${location.pathname}?page=1&date=${dateRange.start + '/' + dateRange.end}`
             if (searchKeyword) {
-                url += `&search=${searchKeyword}`
+                url += `&search=${encodeURIComponent(searchKeyword)}`
+                url += `&sortMode=${encodeURIComponent(sortMode || 'date')}`
             }
             history.push(url)
         }
@@ -135,7 +141,7 @@ class TabList extends Component {
     }
 
     handleDateDelete = () => {
-        const { searchKeyword, history } = this.props
+        const { searchKeyword, history, sortMode } = this.props
         this.setState({ 
             dateRangeActive: false, 
             datesRange: '',
@@ -143,7 +149,8 @@ class TabList extends Component {
         })
         let url = `${location.pathname}?page=1`
         if (searchKeyword) {
-            url += `&search=${searchKeyword}`
+            url += `&search=${encodeURIComponent(searchKeyword)}`
+            url += `&sortMode=${encodeURIComponent(sortMode || 'date')}`
         }
         history.push(url)
     }
@@ -157,9 +164,9 @@ class TabList extends Component {
 
     handleSearchSubmit = () => {
         const { date, history, location } = this.props
-        let { value } = this.state
-        value = encodeURIComponent(value)
-        let url = `${location.pathname}?page=1&search=${value}`
+        let { value, sortMode } = this.state
+        let url = `${location.pathname}?page=1&search=${encodeURIComponent(value)}`
+        url += `&sortMode=${encodeURIComponent(sortMode || 'date')}`
         if (date) {
             url += `&date=${date.start + '/' + date.end}`
         }
@@ -169,7 +176,8 @@ class TabList extends Component {
     handleSearchDelete = () => {
         this.setState({
             value: '',
-            ownUpdate: true 
+            ownUpdate: true,
+            sortMode: 'date'
         })
         const { date, history, location } = this.props
         let url = `${location.pathname}?page=1`
@@ -179,9 +187,33 @@ class TabList extends Component {
         history.push(url)
     }
 
+    handleSortModeChange = (event, { value }) => {
+        const { date, history, location, searchKeyword } = this.props
+        const keyword = this.state.value || searchKeyword
+
+        this.setState({
+            sortMode: value
+        })
+
+        if (!keyword) {
+            return
+        }
+
+        let url = `${location.pathname}?page=1&search=${encodeURIComponent(keyword)}`
+        url += `&sortMode=${encodeURIComponent(value)}`
+        if (date) {
+            url += `&date=${date.start + '/' + date.end}`
+        }
+        history.push(url)
+    }
+
     render() {
-        const { back, value, datesRange, dateRangeActive, edit, noticeId } = this.state
+        const { back, value, datesRange, dateRangeActive, sortMode, edit, noticeId } = this.state
         const { importantUnreadCount, searchKeyword, permission } = this.props
+        const sortOptions = [
+            { key: 'date', text: 'Most recent', value: 'date' },
+            { key: 'relevance', text: 'Most relevant', value: 'relevance' }
+        ]
         
         return (
             <Container styleName='tablist.notice-container-width'>
@@ -296,6 +328,17 @@ class TabList extends Component {
                                             </Form>
                                         )} 
                                     </Menu.Item>
+                                    {searchKeyword ? (
+                                        <Menu.Item>
+                                            <Dropdown
+                                                selection
+                                                compact
+                                                options={sortOptions}
+                                                value={sortMode}
+                                                onChange={this.handleSortModeChange}
+                                            />
+                                        </Menu.Item>
+                                    ) : null}
                                     {permission.length > 0 ? 
                                         (
                                             <Menu.Item
@@ -321,6 +364,7 @@ const mapStateToProps = state => {
     return {
         importantUnreadCount: state.notices.importantUnreadCount,
         searchKeyword: state.notices.searchKeyword,
+        sortMode: state.notices.sortMode,
         page: state.notices.page,
         date: state.notices.dateRange,
         permission: state.permission.permission

--- a/src/components/notice/NoticeList.js
+++ b/src/components/notice/NoticeList.js
@@ -76,8 +76,9 @@ class NoticeList extends Component {
             }
         }
         const searchKeyword = query.get('search')
+        const sortMode = (query.get('sortMode') || 'date').toLowerCase()
         setPosition(position)
-        setFilters(page, dateFilter, searchKeyword, showImp, expired, narrowBookmark, mainCategorySlug, bannerId)
+        setFilters(page, dateFilter, searchKeyword, showImp, expired, narrowBookmark, mainCategorySlug, bannerId, sortMode)
         if (url[2] == 'notice') {
             null
         }
@@ -112,12 +113,15 @@ class NoticeList extends Component {
     // }
 
     handlePaginationChange = (e, data) => {
-        const { date, history, location, searchKeyword } = this.props
+        const { date, history, location, searchKeyword, sortMode } = this.props
         const { pathname } = location
         const { activePage } = data
         let url = `${pathname}?page=${activePage}`
         if(date) url += `&date=${date.start + '/' + date.end}`
-        if(searchKeyword) url += `&search=${searchKeyword}`
+        if(searchKeyword) {
+            url += `&search=${encodeURIComponent(searchKeyword)}`
+            url += `&sortMode=${encodeURIComponent(sortMode || 'date')}`
+        }
         history.push(url)
     }
 
@@ -377,7 +381,6 @@ class NoticeList extends Component {
                             icon='trash alternate'
                             content="Delete, I'm sure"
                             negative
-                            content='Yes'
                             onClick={this.handleConfirm}
                         />
                     </Modal.Actions>
@@ -416,6 +419,7 @@ const mapStateToProps = state => {
         user: state.user.user,
         isFetchingUser: state.user.isFetchingUser,
         searchKeyword: state.notices.searchKeyword,
+        sortMode: state.notices.sortMode,
         date: state.notices.dateRange
     }
 }
@@ -434,8 +438,8 @@ const mapDispatchToProps = dispatch => {
         noticeRead: (list) => {
             dispatch(noticeRead(list))
         },
-        setFilters: (page, dateFilter, searchKeyword, showImp, expired, narrowBookmark, mainCategorySlug, bannerId) => {
-            dispatch(setFilters(page, dateFilter, searchKeyword, showImp, expired, narrowBookmark, mainCategorySlug, bannerId))
+        setFilters: (page, dateFilter, searchKeyword, showImp, expired, narrowBookmark, mainCategorySlug, bannerId, sortMode) => {
+            dispatch(setFilters(page, dateFilter, searchKeyword, showImp, expired, narrowBookmark, mainCategorySlug, bannerId, sortMode))
         },
         setPosition: (position) => {
             dispatch(setPosition(position))

--- a/src/components/sidenav.js
+++ b/src/components/sidenav.js
@@ -8,9 +8,9 @@ import sidenav from '../css/sidenav.css'
 
 class SideNav extends Component {
 
-    filterNotices = (bannerId, searchKeyword = null, dateFilter = null) => {
+    filterNotices = (bannerId, searchKeyword = null, dateFilter = null, sortMode = 'date') => {
         const { history } = this.props
-        history.push(bannerUrl(bannerId, searchKeyword, dateFilter))
+        history.push(bannerUrl(bannerId, searchKeyword, dateFilter, sortMode))
     }
 
     linkUrl = (link, searchKeyword = null, dateFilter = null) => {
@@ -18,14 +18,14 @@ class SideNav extends Component {
     }
 
     renderInnerDropdownItems = items => {
-        const { position, searchKeyword, dateFilter } = this.props
+        const { position, searchKeyword, dateFilter, sortMode } = this.props
         if (items.length) {
             return items.map((item, index) => (
                 <Dropdown.Item
                     key={index}
                     active={position == item.id}
                     onClick={() =>
-                        this.filterNotices(item.id, searchKeyword, dateFilter)
+                        this.filterNotices(item.id, searchKeyword, dateFilter, sortMode)
                     }
                 >
                     {item.name}
@@ -41,14 +41,14 @@ class SideNav extends Component {
     }
 
     renderInnerDropdownAll = item => {
-        const { position, searchKeyword, dateFilter } = this.props
+        const { position, searchKeyword, dateFilter, sortMode } = this.props
         if (item.banner.length) {
             return (
                 <Dropdown.Item
                     key={0}
                     active={position === item.slug}
                     onClick={() =>
-                        this.filterNotices(item.slug, searchKeyword, dateFilter)
+                        this.filterNotices(item.slug, searchKeyword, dateFilter, sortMode)
                     }
                 >
                     All {item.name}
@@ -89,7 +89,7 @@ class SideNav extends Component {
     }
     
     render() {
-        const { filters, searchKeyword, dateFilter, position } = this.props
+        const { filters, searchKeyword, dateFilter, position, sortMode } = this.props
         const { filterNotices } = this
         let outerPosition
         if(filters){
@@ -127,7 +127,7 @@ class SideNav extends Component {
                             ? 'sidenav.sidenav-active-item'
                             : 'sidenav.sidenav-items'
                     }
-                    onClick={() => filterNotices(null, searchKeyword, dateFilter)}
+                    onClick={() => filterNotices(null, searchKeyword, dateFilter, sortMode)}
                 >
                     <Icon styleName='sidenav.sidenav-icon-styling' name='home' />
                     All Notices
@@ -204,6 +204,7 @@ const mapStateToProps = state => {
     return {
         filters: state.filters.filters,
         searchKeyword: state.notices.searchKeyword,
+        sortMode: state.notices.sortMode,
         dateFilter: state.notices.dateRange,
         position: state.position.position
     }

--- a/src/reducers/noticesReducer.js
+++ b/src/reducers/noticesReducer.js
@@ -5,6 +5,7 @@ const initialState = {
     notices: [],
     showImp: false,
     searchKeyword: null,
+    sortMode: 'date',
     narrowBookmark: false,
     expired: false,
     bannerId: null,
@@ -24,6 +25,7 @@ const noticesReducer = (state = initialState, action) => {
             let newState = {
                 ...state,
                 searchKeyword: action.payload.searchKeyword,
+                sortMode: action.payload.sortMode || 'date',
                 isFetchingNotices: false,
                 selectAllActive: false,
                 expired: action.payload.expired,
@@ -44,7 +46,8 @@ const noticesReducer = (state = initialState, action) => {
                 isFetchingNotices: true,
                 notices: [],
                 page: action.payload.page,
-                searchKeyword: action.payload.searchKeyword
+                searchKeyword: action.payload.searchKeyword,
+                sortMode: action.payload.sortMode || 'date'
             }
 
         case 'FETCH_NOTICES_FAILURE':
@@ -118,6 +121,7 @@ const noticesReducer = (state = initialState, action) => {
                 page: action.payload.page,
                 dateRange: action.payload.date,
                 searchKeyword: action.payload.searchKeyword,
+                sortMode: action.payload.sortMode || 'date',
                 showImp: action.payload.showImp,
                 expired: action.payload.expired,
                 narrowBookmark: action.payload.narrowBookmark,

--- a/src/urls.js
+++ b/src/urls.js
@@ -21,14 +21,14 @@ export function filterListUrl() {
     return `${baseApiUrl()}filter_list/`
 }
 
-export function filterUrl(page, banner_id, search_keyword, main_category_slug) {
+export function filterUrl(page, banner_id, search_keyword, main_category_slug, sortMode = 'date') {
     let url
     if (main_category_slug) {
         url = `${baseApiUrl()}filter/?main_category=${banner_id}&page=${page}`
     } else {
         url = `${baseApiUrl()}filter/?banner=${banner_id}&page=${page}`
     }
-    return searchGetParamUrl(url, search_keyword)
+    return searchGetParamUrl(url, search_keyword, sortMode)
 }
 
 export function dateFilterUrl(
@@ -37,7 +37,8 @@ export function dateFilterUrl(
     end,
     banner_id,
     main_category_slug,
-    search_keyword
+    search_keyword,
+    sortMode = 'date'
 ) {
     let url
     url = `${baseApiUrl()}date_filter_view/?start=${start}&end=${end}&page=${page}`
@@ -47,7 +48,7 @@ export function dateFilterUrl(
     } else if (banner_id) {
         url += `&banner=${banner_id}`
     }
-    return searchGetParamUrl(url, search_keyword)
+    return searchGetParamUrl(url, search_keyword, sortMode)
 }
 
 export function addImportantUrl(url) {
@@ -56,26 +57,27 @@ export function addImportantUrl(url) {
     return url
 }
 
-export function searchGetParamUrl(url, search_keyword) {
+export function searchGetParamUrl(url, search_keyword, sortMode = 'date') {
     if (search_keyword) {
         url += `&keyword=${encodeURIComponent(search_keyword)}`
+        url += `&sort=${encodeURIComponent(sortMode || 'date')}`
     }
     return url
 }
 
-export function expiredNoticesUrl(page, search_keyword) {
+export function expiredNoticesUrl(page, search_keyword, sortMode = 'date') {
     let url = `${baseApiUrl()}old/?page=${page}`
-    return searchGetParamUrl(url, search_keyword)
+    return searchGetParamUrl(url, search_keyword, sortMode)
 }
 
-export function importantNoticesUrl(page = 1, search_keyword) {
+export function importantNoticesUrl(page = 1, search_keyword, sortMode = 'date') {
     let url = `${baseApiUrl()}new/?important=true&page=${page}`
-    return searchGetParamUrl(url, search_keyword)
+    return searchGetParamUrl(url, search_keyword, sortMode)
 }
 
-export function noticesUrl(page, search_keyword) {
+export function noticesUrl(page, search_keyword, sortMode = 'date') {
     let url = `${baseApiUrl()}new/?page=${page}`
-    return searchGetParamUrl(url, search_keyword)
+    return searchGetParamUrl(url, search_keyword, sortMode)
 }
 
 export function bookmarkedNoticesUrl(page) {
@@ -104,7 +106,7 @@ export const baseNavUrl = forwardLink => {
     return `${config.baseUrl}${forwardLink}`
 }
 
-export const bannerUrl = (bannerId = null, searchKeyword = null, dateFilter = null) => {
+export const bannerUrl = (bannerId = null, searchKeyword = null, dateFilter = null, sortMode = 'date') => {
     let url = baseNavUrl('/')
     if(bannerId) {
         url += `${bannerId}/`
@@ -115,6 +117,7 @@ export const bannerUrl = (bannerId = null, searchKeyword = null, dateFilter = nu
     }
     if(searchKeyword) {
         url += `&search=${encodeURIComponent(searchKeyword)}`
+        url += `&sortMode=${encodeURIComponent(sortMode || 'date')}`
     }
     return url
 }

--- a/src/urls.js
+++ b/src/urls.js
@@ -58,7 +58,7 @@ export function addImportantUrl(url) {
 
 export function searchGetParamUrl(url, search_keyword) {
     if (search_keyword) {
-        url += `&keyword=${search_keyword}`
+        url += `&keyword=${encodeURIComponent(search_keyword)}`
     }
     return url
 }
@@ -111,10 +111,10 @@ export const bannerUrl = (bannerId = null, searchKeyword = null, dateFilter = nu
     }
     url += `?page=1`
     if(dateFilter) {
-        url += `&date=${dateFilter.start+'/'+dateFilter.end}`
+        url += `&date=${encodeURIComponent(dateFilter.start + '/' + dateFilter.end)}`
     }
     if(searchKeyword) {
-        url += `&search=${searchKeyword}`
+        url += `&search=${encodeURIComponent(searchKeyword)}`
     }
     return url
 }


### PR DESCRIPTION
## Summary

Adds safe URL encoding for Noticeboard search/date query params and adds frontend sort-mode support for Elasticsearch-backed search.

This PR now:

- Encodes search keywords and date filters before writing them into URLs.
- Adds a search sort mode that lets users choose between:
  - `Most recent` -> `sort=date`
  - `Most relevant` -> `sort=relevance`
- Persists the selected sort mode in the frontend URL as `sortMode=...`.
- Sends the selected mode to the backend API as `sort=...`.

Changed areas:

- `src/urls.js`
  - Encodes `keyword`, `search`, `date`, and `sort`/`sortMode` query values.
  - Propagates `sortMode` through URL builders.
- `src/actions/getNotices.js`
  - Reads `sortMode` from Redux state and sends it with notice-fetch requests.
- `src/actions/setFilters.js`
  - Stores `sortMode` alongside the existing filter state.
- `src/reducers/noticesReducer.js`
  - Adds `sortMode` to notice state with `date` as the default.
- `src/components/TabList.js`
  - Adds the `Most recent` / `Most relevant` dropdown for active searches.
  - Updates URLs when the sort mode changes.
- `src/components/notice/NoticeList.js`
  - Reads `sortMode` from the URL and preserves it during pagination.
- `src/components/sidenav.js`
  - Preserves active search sort mode while switching banners/categories.

## Why this PR

This is the `Rewrite`-targeted equivalent of #14, with the additional frontend wiring needed for the Elasticsearch search flow.

Production builds from `Rewrite`, so #14 cannot reach prod even after merge.

`Rewrite` and `master` share no common ancestor and use fundamentally different state models for filter/search:

- `master` stored filter state in `history.push({ state: { searchKeyword, ... } })` and lost it on refresh. Most of #14 is a refactor to fix that by switching to `URLSearchParams`.
- `Rewrite` already drives navigation through `bannerUrl()` writing URL query params, so the full `URLSearchParams` refactor is unnecessary here.
- The URL-encoding bug exists on both branches, so this PR applies the equivalent encoding fix to `Rewrite`.

This PR also adds the frontend piece for the backend search sort API introduced in the Elasticsearch work.

## Why now

Coordinated with the in-flight Elasticsearch search work:

- `omniport-app-noticeboard#22` replaces Postgres `SearchVector` search with a 3-tier Elasticsearch query keyed off the `keyword=` GET param.
- That backend also supports `sort=date` and `sort=relevance`.
- Without encoding, searches containing `&`, `=`, `#`, `+`, `%`, `/`, or whitespace can break the API call.
- Without frontend sort-mode wiring, users cannot request relevance-ordered Elasticsearch results from the UI.
- `omniport-docker#52` and the env-wiring PR provision Elasticsearch through sidecar/env-driven host configuration for dev and prod.