### PR TITLE
Show year in notice list dates

### DIFF
--- a/src/components/notice/NoticeCell.js
+++ b/src/components/notice/NoticeCell.js
@@ -145,9 +145,7 @@ class NoticeCell extends Component {
                     collapsing
                     styleName='notice.cell-width-2 notice.cell-hover'
                 >
-                    {moment(date).format(
-                        Date.now().year === moment(date).year() ? 'DD/MM/YY' : 'MMM Do'
-                    )}
+                    {moment(date).format('MMM Do, YYYY')}
                 </Table.Cell>
                 {permission.length > 0 ? 
                     (

--- a/src/components/notice/NoticeList.js
+++ b/src/components/notice/NoticeList.js
@@ -204,9 +204,9 @@ class NoticeList extends Component {
         }
         if (dateRange) {
             dateDisplay =
-                moment(dateRange.start).format('MMM Do') +
-                ' to ' +
-                moment(dateRange.end).format('MMM Do')
+                moment(dateRange.start).format('MMM Do, YYYY') +
+                ' - ' +
+                moment(dateRange.end).format('MMM Do, YYYY')
         }
         
         return (


### PR DESCRIPTION
Updated notice list date formatting to always include the year.
<img width="1296" height="647" alt="Screenshot 2026-05-20 145516" src="https://github.com/user-attachments/assets/9bac92c0-cae2-45d7-86aa-070e48624105" />

Date filter summary also shows the year.
<img width="1337" height="535" alt="image" src="https://github.com/user-attachments/assets/79001a3b-d0d1-445e-abd5-0a1eccbf87c4" />

